### PR TITLE
feat(watcher): add optional root config

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use log::info;
+use std::path::PathBuf;
 use std::process::Child;
 
 use clap::Parser;
@@ -49,6 +50,10 @@ struct Config {
     #[arg(short, long, default_value = ":")]
     command: String,
 
+    /// Optional root
+    #[arg(long)]
+    root: Option<PathBuf>,
+
     /// Poll duration (ms)
     #[arg(long, default_value_t = 500)]
     poll: u64,
@@ -68,7 +73,7 @@ fn main() -> Result<(), SsfwError> {
     info!("Command:\t{}", &config.command);
     info!("Pattern:\t{}", &config.pattern);
     let pattern = glob::Pattern::new(&config.pattern)?;
-    Watcher::new()
+    Watcher::new(&config.root)
         .poll_interval(config.poll)
         .watch(pattern, |path| {
             let mut child: Option<Child> = None;

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,4 +1,4 @@
-use log::{error, info};
+use log::{debug, error, info};
 use notify::{Config, EventKind, PollWatcher, RecursiveMode, Watcher as NotifyWatcher};
 use std::{
     path::{Path, PathBuf},
@@ -12,10 +12,10 @@ pub(crate) struct Watcher {
 }
 
 impl Watcher {
-    pub fn new() -> Self {
+    pub fn new(root: &Option<PathBuf>) -> Self {
         let cwd = std::env::current_dir().unwrap();
         Self {
-            root: cwd,
+            root: root.clone().unwrap_or(cwd),
             poll: 500,
         }
     }
@@ -39,6 +39,7 @@ impl Watcher {
         for res in receiver {
             match res {
                 Ok(event) => {
+                    debug!("{:?}", &event);
                     let paths: Vec<&Path> = event.paths.iter().map(|pb| pb.as_path()).collect();
                     let event_type = match event.kind {
                         EventKind::Create(_) => "CREATE",


### PR DESCRIPTION
Adds a `--root` option for user's to specify a watch root other than `cwd`.
